### PR TITLE
Enable sonar scan on dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,3 +94,4 @@ jobs:
         uses: minvws/action-sonarqube@v1
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
+          allow-run-on-dependabot: true


### PR DESCRIPTION
Lets try to see if dependabot has secret available for sonar.

As the check is currently set as required.

<img width="980" height="203" alt="image" src="https://github.com/user-attachments/assets/158e4567-68cb-45ef-a983-c82034eced94" />
