### PR TITLE
chore: fix indentation in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-  - directory: "/"
-  - schedule:
-  - interval: "weekly"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 
   - package-ecosystem: "composer" # See documentation for possible values
     directory: "/" # Location of package manifests


### PR DESCRIPTION
This PR fixes the indentation in dependabot config