### PR TITLE
chore: Enable SonarQube scan on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,4 @@ jobs:
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           allow-run-on-dependabot: true
+          allow-run-on-fork: true


### PR DESCRIPTION
Added option to allow runs on forks in SonarQube scan.